### PR TITLE
cut error message at the first null byte, and ignore non-utf8 chars

### DIFF
--- a/src/oci_error.rs
+++ b/src/oci_error.rs
@@ -125,14 +125,9 @@ pub(crate) fn get_error(
         match error_result.into() {
             ReturnCode::NoData => break,
             ReturnCode::Success => {
-                let oracle_error_text = match String::from_utf8(Vec::from(&error_message[..])) {
-                    Ok(text) => text,
-                    Err(err) => format!(
-                        "Oracle error text is unreadable due
-                                to it not being utf8: {}",
-                        err
-                    ).to_string(),
-                };
+                let first_null_byte_index = error_message.iter().position(|&x| x == 0).unwrap();
+                let oracle_error_text = String::from_utf8_lossy(&error_message[0..first_null_byte_index]).into_owned();
+
                 error_record.add_error(error_code, oracle_error_text)
             }
             ReturnCode::Error => {


### PR DESCRIPTION
When hitting an error, I'm getting (note the `\u{0}` at the end):

    thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Oracle(ErrorRecord { description: "Database connection", records: [(12543, "ORA-12543: TNS:destination host unreachable\n\u{0}\u{0}...

I believe that C code would truncate the error message at the first null byte, since this is how C-strings work. This commit truncates the string at the first null byte.

Also, no error is returned if the string contains non-utf8 chars, instead, they are replaced with `�`.
You can skip this part if you prefer.