### PR TITLE
Enable building on `windows-gnu` toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ readme = "CRATEREADME.md"
 libc = "0.2.23"
 byteorder = "1.0.0"
 chrono = "0.4.0"
+
+[build-dependencies]
+build-helper = "0.1.1"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ according to your distro. The below works on [OpenSuse][8].
 export LIBRARY_PATH=$LIBRARY_PATH:/usr/lib/oracle/12.2/client64/lib/
 ```
 
-This crate has been briefly tested against Windows but difficulties were faced. The OCI library is named differently and so updates will be needed in the bindings to make it compile. Once I can get chance to work out how to even build this using Visual Studio on Windows, this will be addressed.
+You can build this crate on Windows hosts using the `windows-gnu` toolchain. The only requirement for this is that `oci.dll` is on the PATH.
+
+Building against `windows-msvc` has been briefly tested but difficulties were faced. Once I can get chance to work out how to even build this using Visual Studio on Windows, this will be addressed.
 
 Testing has been done against a local installation of [Oracle 11g Express Edition][9].
 In order to run the crate tests then a local database needs to be

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,11 @@
+extern crate build_helper;
+
+use build_helper::{rustc, target, LibKind};
+
+fn main() {
+    let lib_name = match target::triple().os() {
+        "windows" => "oci",
+        _ => "clntsh"
+    };
+    rustc::link_lib(Some(LibKind::DyLib), lib_name);
+}

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,10 @@
 extern crate build_helper;
 
-use build_helper::{rustc, target, LibKind};
+use build_helper::{rustc, target, host, SearchKind, LibKind};
+
+use std::env;
+use std::fs::ReadDir;
+use std::path::PathBuf;
 
 fn main() {
     let lib_name = match target::triple().os() {
@@ -8,4 +12,37 @@ fn main() {
         _ => "clntsh"
     };
     rustc::link_lib(Some(LibKind::DyLib), lib_name);
+
+    let host = host();
+    match (host.os(), host.env()) {
+        ("windows", Some("gnu")) => if let Some(path) = find_dll(lib_name) {
+            rustc::link_search(Some(SearchKind::Native), path);
+        },
+        _ => ()
+
+    }
+}
+
+fn find_dll(dll_name: &str) -> Option<PathBuf> {
+    assert_eq!(host().os(), "windows");
+    let contains_dll = |mut contained_files: ReadDir| {
+        contained_files
+            .any(|maybe_entry| {
+                maybe_entry
+                    .ok()
+                    .and_then(|entry| entry.file_name().into_string().ok())
+                    .map(|file_name| file_name.to_lowercase() == dll_name.to_string() + ".dll")
+                    .unwrap_or(false)
+            })
+    };
+    env::var_os("PATH")
+        .and_then(|paths| {
+            env::split_paths(&paths)
+                .filter(|path| {
+                    path.read_dir()
+                        .map(&contains_dll)
+                        .unwrap_or(false)
+                })
+                .next()
+        })
 }

--- a/src/oci_bindings.rs
+++ b/src/oci_bindings.rs
@@ -415,7 +415,8 @@ impl From<OciNumberType> for c_uint {
     }
 }
 
-#[link(name = "clntsh")]
+// Note: The library name is selected in the build script because it is different
+// for each platform.
 extern "C" {
     /// Creates the environment handle. The signature has been changed to only
     /// allow null pointers for the user defined memory parameters. This means

--- a/src/types.rs
+++ b/src/types.rs
@@ -309,14 +309,14 @@ fn create_datetime_from_raw(data: &[u8]) -> DateTime<Utc> {
     let minute = convert_minute(data[5]);
     let second = convert_second(data[6]);
     if data.len() <= 7 {
-        Utc.ymd((century + year), month, day).and_hms(
+        Utc.ymd(century + year, month, day).and_hms(
             hour,
             minute,
             second,
         )
     } else {
         let nano = convert_nano(&data[7..11]);
-        Utc.ymd((century + year), month, day).and_hms_nano(
+        Utc.ymd(century + year, month, day).and_hms_nano(
             hour,
             minute,
             second,
@@ -377,7 +377,7 @@ fn create_datetime_with_timezone_from_raw(data: &[u8]) -> DateTime<FixedOffset> 
     let timezone_minute = convert_timezone_minute(data[12]);
     let hour_in_secs = timezone_hour * 3600;
     let minutes_in_secs = timezone_minute * 60;
-    let utc_dt = Utc.ymd((century + year), month, day).and_hms_nano(
+    let utc_dt = Utc.ymd(century + year, month, day).and_hms_nano(
         hour,
         minute,
         second,


### PR DESCRIPTION
This allows building on `windows-gnu` if `oci.dll` is on the `PATH`, which is where Windows will look for the DLL when running the binary anyway. There are no other requirements because the GNU linker can link DLLs directly, so setting up for development is very easy.

On `windows-msvc` you'll probably have to generate an import library for oci.dll and distribute that with the crate, like `winapi` does. It's definitely more complicated than the GNU toolchain.